### PR TITLE
additional 'no-uninstalled-addons' support

### DIFF
--- a/lib/rules/no-uninstalled-addons.ts
+++ b/lib/rules/no-uninstalled-addons.ts
@@ -252,18 +252,9 @@ export = createStorybookRule({
       },
       ExportDefaultDeclaration: function (node) {
         const meta = getMetaObjectExpression(node, context)
-        if (!meta) {
-          return null
-        }
+        if (!meta) return null
 
-        const addonsProp = meta.properties.find(
-          (prop): prop is TSESTree.Property =>
-            isProperty(prop) && isIdentifier(prop.key) && prop.key.name === 'addons'
-        )
-
-        if (addonsProp && addonsProp.value && isArrayExpression(addonsProp.value)) {
-          reportUninstalledAddons(addonsProp.value)
-        }
+        findAddonsPropAndReport(meta)
       },
       ExportNamedDeclaration: function (node) {
         const addonsProp =

--- a/tests/lib/rules/no-uninstalled-addons.test.ts
+++ b/tests/lib/rules/no-uninstalled-addons.test.ts
@@ -46,6 +46,27 @@ ruleTester.run('no-uninstalled-addons', rule, {
     }
   `,
     `
+    export default {
+      addons: [
+        "@storybook/addon-links",
+        "@storybook/addon-essentials",
+        "@storybook/addon-interactions",
+        "@storybook/preset-create-react-app"
+      ]
+    } satisfies StorybookConfig
+  `,
+    `
+     const config: StorybookConfig = {
+        addons: [
+        "@storybook/addon-links",
+        "@storybook/addon-essentials",
+        "@storybook/addon-interactions",
+        "@storybook/preset-create-react-app"
+        ]
+      }
+      export default config
+  `,
+    `
     export const addons = [
       "@storybook/addon-links",
       "@storybook/addon-essentials",
@@ -271,6 +292,69 @@ ruleTester.run('no-uninstalled-addons', rule, {
           "@storybook/addon-esentials",
         ]
       }
+      `,
+      errors: [
+        {
+          messageId: 'addonIsNotInstalled', // comes from the rule file
+          type: AST_NODE_TYPES.Literal,
+          data: {
+            addonName: 'addon-withut-the-prefix',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
+          },
+        },
+        {
+          messageId: 'addonIsNotInstalled', // comes from the rule file
+          type: AST_NODE_TYPES.Literal,
+          data: {
+            addonName: '@storybook/addon-esentials',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      export default {
+        addons: [
+          "@storybook/addon-links",
+          "@storybook/addon-essentials",
+          "@storybook/addon-interactions",
+          "addon-withut-the-prefix",
+          "@storybook/addon-esentials",
+        ]
+      } satisfies StorybookConfig
+      `,
+      errors: [
+        {
+          messageId: 'addonIsNotInstalled', // comes from the rule file
+          type: AST_NODE_TYPES.Literal,
+          data: {
+            addonName: 'addon-withut-the-prefix',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
+          },
+        },
+        {
+          messageId: 'addonIsNotInstalled', // comes from the rule file
+          type: AST_NODE_TYPES.Literal,
+          data: {
+            addonName: '@storybook/addon-esentials',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      const config: StorybookConfig = {
+        addons: [
+          "@storybook/addon-links",
+          "@storybook/addon-essentials",
+          "@storybook/addon-interactions",
+          "addon-withut-the-prefix",
+          "@storybook/addon-esentials",
+        ]
+      }
+      export default config
       `,
       errors: [
         {


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

no-uninstalled-addons now works with 2 additional export ways 

([as shown in the docs](https://storybook.js.org/docs/react/configure/overview)) 
```
const config: StorybookConfig = {
...
};

export default config;
```
&
```
export default {
  addons: [
	...
  ],
} satisfies StorybookConfig;

```
 

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
